### PR TITLE
patch: add decorator to reject msgCreateClawbackVestingAccount in anteHandler

### DIFF
--- a/app/ante/handler_options.go
+++ b/app/ante/handler_options.go
@@ -84,6 +84,7 @@ func newCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		cosmosante.NewAuthzLimiterDecorator(
 			sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}),
 			sdk.MsgTypeURL(&sdkvesting.MsgCreateVestingAccount{}),
+			sdk.MsgTypeURL(&vestingtypes.MsgCreateClawbackVestingAccount{}),
 		),
 		ante.NewSetUpContextDecorator(),
 		ante.NewRejectExtensionOptionsDecorator(),
@@ -114,6 +115,7 @@ func newCosmosAnteHandlerEip712(options HandlerOptions) sdk.AnteHandler {
 		cosmosante.NewAuthzLimiterDecorator(
 			sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}),
 			sdk.MsgTypeURL(&sdkvesting.MsgCreateVestingAccount{}),
+			sdk.MsgTypeURL(&vestingtypes.MsgCreateClawbackVestingAccount{}),
 		),
 		ante.NewSetUpContextDecorator(),
 		ante.NewMempoolFeeDecorator(),

--- a/app/ante/handler_options.go
+++ b/app/ante/handler_options.go
@@ -94,7 +94,7 @@ func newCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		ante.NewValidateMemoDecorator(options.AccountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper),
-		NewVestingDelegationDecorator(options.AccountKeeper, options.StakingKeeper, options.Cdc),
+		NewRejectClawbackVestingAccount(),
 		NewValidatorCommissionDecorator(options.Cdc),
 		// SetPubKeyDecorator must be called before all signature verification decorators
 		ante.NewSetPubKeyDecorator(options.AccountKeeper),
@@ -123,7 +123,7 @@ func newCosmosAnteHandlerEip712(options HandlerOptions) sdk.AnteHandler {
 		ante.NewValidateMemoDecorator(options.AccountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper),
-		NewVestingDelegationDecorator(options.AccountKeeper, options.StakingKeeper, options.Cdc),
+		NewRejectClawbackVestingAccount(),
 		NewValidatorCommissionDecorator(options.Cdc),
 		// SetPubKeyDecorator must be called before all signature verification decorators
 		ante.NewSetPubKeyDecorator(options.AccountKeeper),

--- a/app/ante/vesting.go
+++ b/app/ante/vesting.go
@@ -27,11 +27,11 @@ func NewEthVestingTransactionDecorator(ak evmtypes.AccountKeeper) EthVestingTran
 // vesting cliff and lockup period.
 //
 // This AnteHandler decorator will fail if:
-//  - the message is not a MsgEthereumTx
-//  - sender account cannot be found
-//  - sender account is not a ClawbackvestingAccount
-//  - blocktime is before surpassing vesting cliff end (with zero vested coins) AND
-//  - blocktime is before surpassing all lockup periods (with non-zero locked coins)
+//   - the message is not a MsgEthereumTx
+//   - sender account cannot be found
+//   - sender account is not a ClawbackvestingAccount
+//   - blocktime is before surpassing vesting cliff end (with zero vested coins) AND
+//   - blocktime is before surpassing all lockup periods (with non-zero locked coins)
 func (vtd EthVestingTransactionDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
 	for _, msg := range tx.GetMsgs() {
 		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
@@ -173,4 +173,24 @@ func (vdd VestingDelegationDecorator) validateMsg(ctx sdk.Context, msg sdk.Msg) 
 	}
 
 	return nil
+}
+
+// RejectClawbackVestingAccount prevents MsgCreateClawbackVestingAccount from being executed
+type RejectClawbackVestingAccount struct{}
+
+func (rvd RejectClawbackVestingAccount) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	for _, msg := range tx.GetMsgs() {
+		if _, ok := msg.(*vestingtypes.MsgCreateClawbackVestingAccount); ok {
+			return ctx, sdkerrors.Wrapf(
+				sdkerrors.ErrInvalidType,
+				"cannot create clawback vesting account with MsgCreateClawbackVestingAccount",
+			)
+		}
+	}
+	return next(ctx, tx, simulate)
+}
+
+// NewVestingDelegationDecorator creates a new VestingDelegationDecorator
+func NewRejectClawbackVestingAccount() RejectClawbackVestingAccount {
+	return RejectClawbackVestingAccount{}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -144,6 +144,7 @@ import (
 	v3 "github.com/Canto-Network/Canto/v6/app/upgrades/v3"
 	v4 "github.com/Canto-Network/Canto/v6/app/upgrades/v4"
 	v5 "github.com/Canto-Network/Canto/v6/app/upgrades/v5"
+	v6 "github.com/Canto-Network/Canto/v6/app/upgrades/v6"
 )
 
 func init() {
@@ -1104,6 +1105,8 @@ func (app *Canto) setupUpgradeHandlers() {
 		storeUpgrades = &storetypes.StoreUpgrades{
 			Added: []string{csrtypes.StoreKey},
 		}
+	case v6.UpgradeName:
+		// no store upgrades in v6
 	}
 
 	if storeUpgrades != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -1077,6 +1077,12 @@ func (app *Canto) setupUpgradeHandlers() {
 		v5.CreateUpgradeHandler(app.mm, app.configurator),
 	)
 
+	// v6 upgrade handler
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v6.UpgradeName,
+		v6.CreateUpgradeHandler(app.mm, app.configurator),
+	)
+
 	// When a planned update height is reached, the old binary will panic
 	// writing on disk the height and name of the update that triggered it
 	// This will read that value, and execute the preparations for the upgrade.

--- a/app/upgrades/v6/constants.go
+++ b/app/upgrades/v6/constants.go
@@ -1,0 +1,6 @@
+package v6
+
+const (
+	//UpgradeName is the name of the upgrade to be associated with the chain upgrade
+	UpgradeName = "v6.0.0"
+)

--- a/app/upgrades/v6/upgrades.go
+++ b/app/upgrades/v6/upgrades.go
@@ -1,0 +1,21 @@
+package v6
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+// CreateUpgradeHandler creates an SDK upgrade handler for v6
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		logger := ctx.Logger().With("upgrade: ", UpgradeName)
+
+		// Leave modules are as-is to avoid running InitGenesis.
+		logger.Debug("running module migrations ...")
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}


### PR DESCRIPTION
## Description
- this patch rejects MsgCreateClawbackVestingAccount in ante handler
- adds new decorate RejectClawbackVestingAccount in vesting.go
- replace old vesting decorator with new reject decorator

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration tests
- [x] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
